### PR TITLE
multihash key gen func

### DIFF
--- a/pkg/shared/functions.go
+++ b/pkg/shared/functions.go
@@ -1,0 +1,19 @@
+package shared
+
+import (
+	blockstore "github.com/ipfs/go-ipfs-blockstore"
+	dshelp "github.com/ipfs/go-ipfs-ds-help"
+	"github.com/multiformats/go-multihash"
+)
+
+const SSZ_SHA2_256_PREFIX int = 0xb501
+
+// MultihashKeyFromSSZRoot converts a SSZ-SHA2-256 root hash into a blockstore prefixed multihash key
+func MultihashKeyFromSSZRoot(root []byte) (string, error) {
+	mh, err := multihash.Encode(root, SSZ_SHA2_256_PREFIX)
+	if err != nil {
+		return "", err
+	}
+	dbKey := dshelp.MultihashToDsKey(mh)
+	return blockstore.BlockPrefix.String() + dbKey.String(), nil
+}


### PR DESCRIPTION
Function for converting a SSZ SHA2-256 Merkle root into a blockstore-prefixed multihash key. Wasn't sure where you'd want to put it, so it's in a new `shared` pkg.

The PR to canonize the byte prefix isn't merged yet so it is still subject to change.